### PR TITLE
Fix media-queries

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["stylelint-config-standard"]
+  "extends": ["stylelint-config-standard"],
+  "rules" : {
+    "media-feature-range-notation": "prefix"
+  }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -41,7 +41,7 @@
   border-color: var(--color-cyan);
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   .columns > div {
     flex-direction: unset;
     gap: 24px;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -41,13 +41,13 @@ header nav[aria-expanded="true"] {
   min-height: 100vh;
 }
 
-@media (width >= 600px) {
+@media (min-width: 600px) {
   header nav {
     padding: 0 2rem;
   }
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav {
     display: grid;
   }
@@ -139,7 +139,7 @@ header nav[aria-expanded="true"] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav .nav-hamburger {
     display: none;
     visibility: hidden;
@@ -194,7 +194,7 @@ header nav .nav-sections ul > li > ul > li {
   font-size: .875rem;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav .nav-sections {
     display: block;
     visibility: visible;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -106,13 +106,13 @@
   /* misc */
   --nav-height: 125px;
   --section-width: 990pt;
-  
+
   /* font weights */
   --lato-regular: 400;
   --lato-bold: 700;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   :root {
     --heading-font-size-xxl: 48px;
     --heading-font-size-xl: 32px;
@@ -276,13 +276,13 @@ main .section {
   padding: 16px;
 }
 
-@media (width >= 600px) {
+@media (min-width: 600px) {
   main .section {
     padding: 32px;
   }
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   .section > div {
     max-width: var(--section-width);
     margin: auto;


### PR DESCRIPTION
Use old media-query notation for backwards compatability.

Test URLs:
- Before: https://main--shredit--stericycle.aem.page/
- After: https://fix-media-queries--shredit--stericycle.aem.page/
- After: https://fix-media-queries--stericycle-shared--aemsites.hlx.page/en-us
