### PR TITLE
Fix column styling to match the original page

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -35,9 +35,22 @@
 .columns.cyan-accent-border > div > div,
 .columns.orange-accent-border.columns-has-image > div > div > p:not(:has(img)),
 .columns.cyan-accent-border.columns-has-image > div > div > p:not(:has(img)) {
-  border-width: 0 0 0 4px;
-  border-style: solid;
-  padding-left: 1.5rem;
+  justify-content: unset;
+  position: relative;
+  padding-left: 24px;
+}
+
+.columns.orange-accent-border > div > div::after,
+.columns.cyan-accent-border > div > div::after,
+.columns.orange-accent-border.columns-has-image > div > div > p:not(:has(img))::after,
+.columns.cyan-accent-border.columns-has-image > div > div > p:not(:has(img))::after {
+  position: absolute;
+  left: 0;
+  max-height: 80px;
+  height: 100%;
+  width: 4px;
+  content: '';
+  display: block;
 }
 
 .columns.orange-accent-border.columns-has-image > div > div > p:not(:has(img)),
@@ -48,14 +61,14 @@
   margin-top: 1rem;
 }
 
-.columns.orange-accent-border > div > div,
-.columns.orange-accent-border.columns-has-image > div > div > p:not(:has(img)) {
-  border-color: var(--color-orange);
+.columns.orange-accent-border > div > div::after,
+.columns.orange-accent-border.columns-has-image > div > div > p:not(:has(img))::after {
+  background: var(--color-orange);
 }
 
-.columns.cyan-accent-border > div > div,
-.columns.cyan-accent-border.columns-has-image > div > div > p:not(:has(img)) {
-  border-color: var(--color-cyan);
+.columns.cyan-accent-border > div > div::after,
+.columns.cyan-accent-border.columns-has-image > div > div > p:not(:has(img))::after {
+  background: var(--color-cyan);
 }
 
 .columns.orange-accent-border.columns-has-image > div > div,


### PR DESCRIPTION
Test URLs:
- Before: https://main--shredit--stericycle.aem.page/drafts/janlucaa/locations/location-type-2
- After: 
  - https://fix-column-accent--shredit--stericycle.aem.page/drafts/janlucaa/locations/location-type-2
  - https://fix-column-accent--stericycle-shared--aemsites.aem.page/drafts/janlucaa/locations/location-type-2

Before:

![Screenshot 2024-08-29 at 08 39 31](https://github.com/user-attachments/assets/37603150-c8b3-45b9-b3d6-7bbab209e5a7)

After:

![Screenshot 2024-08-29 at 08 38 58](https://github.com/user-attachments/assets/d9983ff6-179a-4cd1-93f3-8647586153ad)
