### PR TITLE
External links in new tab and previous lint error removed

### DIFF
--- a/blocks/service-location-map/service-location-map.js
+++ b/blocks/service-location-map/service-location-map.js
@@ -19,7 +19,7 @@ import {
 } from '../../scripts/aem.js';
 import ffetch from '../../scripts/ffetch.js';
 import usStates from './us-states.js';
-import { getLocale } from '../../scripts/scripts.js';
+import { decorateAnchors, getLocale } from '../../scripts/scripts.js';
 
 let map = null;
 
@@ -554,5 +554,6 @@ export default async function decorate(block) {
 
   calculateLocationListDistance(locations, getCenterPoint());
   renderAndSortLocationList(locations, block, ph);
+  decorateAnchors(block);
   window.setTimeout(() => mapInitialization(locations, block, ph), 3000);
 }

--- a/blocks/simple-cta/simple-cta.js
+++ b/blocks/simple-cta/simple-cta.js
@@ -1,3 +1,5 @@
+import { decorateAnchors } from '../../scripts/scripts.js';
+
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
   block.classList.add(`simple-cta-${cols.length}-cols`);
@@ -12,7 +14,7 @@ export default function decorate(block) {
       const pic = col.querySelector('picture');
       const link = col.querySelector('a');
 
-      if (pic && link && link.href
+      if (pic && link?.href
         && new URL(link.href).pathname === new URL(link.innerText).pathname) {
         link.innerHTML = '';
         link.appendChild(pic);
@@ -31,4 +33,6 @@ export default function decorate(block) {
       }
     });
   });
+
+  decorateAnchors(block);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -275,6 +275,33 @@ async function decorateTemplates(main) {
 }
 
 /**
+ * decorates external links to open in new window
+ * for styling updates via CSS
+ * @param {Element}s element The element to decorate
+ * @returns {void}
+ */
+export function decorateExternalAnchors(externalAnchors) {
+  if (externalAnchors.length) {
+    externalAnchors.forEach((a) => {
+      a.target = '_blank';
+    });
+  }
+}
+
+/**
+ * decorates anchors
+ * for styling updates via CSS
+ * @param {Element} element The element to decorate
+ * @returns {void}
+ */
+export function decorateAnchors(element = document) {
+  const anchors = element.getElementsByTagName('a');
+  decorateExternalAnchors(Array.from(anchors).filter(
+    (a) => a.href && !a.href.match(`^http[s]*://${window.location.host}/`),
+  ));
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -282,6 +309,7 @@ async function decorateTemplates(main) {
 export function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
+  decorateAnchors(main);
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #155 

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.live/en-us/service-locations/boston
- After: 
  - https://external-links--shredit--stericycle.aem.live/en-us/service-locations/boston
