### PR TITLE
Changed Label of next button to continue in wizard.

### DIFF
--- a/blocks/form/components/wizard/wizard.js
+++ b/blocks/form/components/wizard/wizard.js
@@ -159,7 +159,7 @@ export class WizardLayout {
 
     if (this.includeNextBtn && children.length) {
       this.addButton(wrapper, panel, {
-        label: { value: 'Next' }, fieldType: 'button', name: 'next', id: 'wizard-button-next',
+        label: { value: 'Continue' }, fieldType: 'button', name: 'next', id: 'wizard-button-next',
       });
     }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.page/forms/multistep-inline-purge
- After: 
  - https://continuebtn--shredit--stericycle.aem.page/forms/multistep-inline-purge
- After: 
