### PR TITLE
fix: prevent scroll position getting reset when modal is opened

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -9,7 +9,7 @@ body.modal-open {
 .modal dialog {
   overscroll-behavior: none;
   overflow-y: hidden;
-  position: relative;
+  position: fixed;
   width: calc(100vw - 48px);
   max-width: 900px;
   max-height: calc(100dvh - (2 * var(--header-height)));


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #483 

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.page/
- After: 
  - https://issue483--shredit--stericycle.aem.page/
