### PR TITLE
STERI016-61-split-button-am: Atom - Split Button

### DIFF
--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -1326,6 +1326,7 @@ main .form form fieldset.splitbuttons {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    margin: 24px 0 0;
 }
 
 main .form form fieldset.splitbuttons .radio-wrapper-container {
@@ -1347,9 +1348,21 @@ main .form form fieldset.splitbuttons .radio-wrapper-container .radio-wrapper:la
 }
 
 main .form form fieldset.splitbuttons legend {
+    font-family: var(--font-family-lato);
+    font-size: var(--form-font-size-xxs);
+    font-weight:var(--font-weight-bold);
+    color: var(--color-text-primary);
+    line-height: 22.4px;
     margin-right: 8px;
     max-width: 102px;
     width: fit-content;
+}
+
+@media (min-width: 1000px) {
+    main .form form fieldset.splitbuttons legend {
+        font-size: var(--form-font-size-xs);
+        line-height: 25.6px;
+    }
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper {

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -374,8 +374,8 @@ main .submit-wrapper{
     width: var(--form-submit-width);
 }
 
-main .form input:focus, 
-main .form textarea:focus, 
+main .form input:focus,
+main .form textarea:focus,
 main .form select:focus {
   outline: 3px solid var(--color-bg-tertiary);
   outline-offset: 3px;
@@ -792,7 +792,6 @@ main .form .field-wrapper.floating-field > label {
     top: 10px;
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper label,
 main .form form .panel-wrapper.field-frequncy .radio-wrapper label{
     color: var(--color-white);
     cursor: pointer;
@@ -819,7 +818,6 @@ main .form .field-wrapper.floating-field input:not([type='radio'], [type='checkb
     color: transparent;
 }
 
-main .form form .panel-wrapper.field-requesttype,
 main .form form .panel-wrapper.field-frequncy{
     grid-template-columns: 12fr 1fr 1fr;
     gap: 0;
@@ -827,7 +825,6 @@ main .form form .panel-wrapper.field-frequncy{
     margin-bottom: 20px;
 }
 
-main .form form .panel-wrapper.field-requesttype legend,
 main .form form .panel-wrapper.field-frequncy legend{
   grid-column: 1;
 }
@@ -837,37 +834,31 @@ main .form form .panel-wrapper.field-frequncy .radio-wrapper input{
   opacity: 0;
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper,
 main .form form .panel-wrapper.field-frequncy .radio-wrapper{
     position: relative;
     grid-column: 2;
     display: flex;
     align-items: center;
-    margin-top: -45px;
     width: 120px;
     text-align: center;
     background: var(--form-styles-border-color);
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper:nth-child(2),
 main .form form .panel-wrapper.field-frequncy .radio-wrapper:nth-child(2){
   border-bottom-left-radius: 6.25rem;
   border-top-left-radius: 6.25rem;
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper:nth-child(3),
 main .form form .panel-wrapper.field-frequncy .radio-wrapper:nth-child(3){
   grid-column: 3;
   border-bottom-right-radius: 6.25rem;
   border-top-right-radius: 6.25rem;
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper:has(input:checked),
 main .form form .panel-wrapper.field-frequncy .radio-wrapper:has(input:checked){
   background: var(--form-styles-button-primary-color);
 }
 
-main .form form .panel-wrapper.field-requesttype .radio-wrapper:has(input:checked) label::before,
 main .form form .panel-wrapper.field-frequncy .radio-wrapper:has(input:checked) label::before{
   content: '';
   display: block;
@@ -1328,4 +1319,95 @@ main form .fragment-wrapper[data-id^='policy']  p{
 
 main .campaign-form.form form .fragment-wrapper div > p {
     font-size: 1rem;
+}
+
+/* Split buttons */
+main .form form fieldset.splitbuttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+main .form form fieldset.splitbuttons .radio-wrapper-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: 8px;
+    height: 100%;
+}
+
+main .form form fieldset.splitbuttons .radio-wrapper-container .radio-wrapper:first-of-type {
+    border-bottom-left-radius: 6.25rem;
+    border-top-left-radius: 6.25rem;
+}
+
+main .form form fieldset.splitbuttons .radio-wrapper-container .radio-wrapper:last-of-type {
+    border-bottom-right-radius: 6.25rem;
+    border-top-right-radius: 6.25rem;
+}
+
+main .form form fieldset.splitbuttons legend {
+    margin-right: 8px;
+    max-width: 102px;
+    width: fit-content;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper {
+    position: relative;
+    grid-column: 2;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    gap: 0;
+    background: var(--color-bg-secondary);
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper input {
+    visibility: hidden;
+    width: 0;
+    height: 0;
+    margin: 0;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
+    padding: 11px 32px;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) {
+    background: var(--form-styles-button-primary-color);
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 32px;
+    background: url("/icons/check-mark-new.svg") no-repeat left center;
+    background-size: cover;
+    width: 16px;
+    height: 16px;
+
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
+    color: var(--color-text-primary);
+    cursor: pointer;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) {
+    position: relative;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label {
+    display: flex;
+    align-items: center;
+    color: var(--color-white);
+    cursor: pointer;
+    padding-left: 56px;
+}
+
+main .form form .panel-wrapper.splitbuttons .radio-wrapper.field-wrapper {
+    width: fit-content;
+    padding: 0;
+    margin-top: 0;
 }

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -1403,6 +1403,10 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
     }
 }
 
+main .two-column.form-container .form form .panel-wrapper.splitbuttons .radio-wrapper label {
+    padding: 11px 22px;
+}
+
 main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) {
     background: var(--form-styles-button-primary-color);
 }
@@ -1422,6 +1426,10 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) la
     main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label::before {
         left: 32px;
     }
+}
+
+main .two-column.form-container .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label::before {
+    left: 22px;
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
@@ -1455,6 +1463,10 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) la
     main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label {
        padding-left: 56px;
     }
+}
+
+main .two-column.form-container .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label {
+    padding-left: 46px;
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper.field-wrapper {

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -1324,9 +1324,18 @@ main .campaign-form.form form .fragment-wrapper div > p {
 /* Split buttons */
 main .form form fieldset.splitbuttons {
     display: flex;
-    flex-direction: row;
+    flex-flow: column;
     justify-content: space-between;
+    align-items: flex-start;
     margin: 24px 0 0;
+    gap: 8px;
+}
+@media (min-width: 370px) {
+    main .form form fieldset.splitbuttons {
+        flex-flow: row;
+        align-items: start;
+        gap: 8px;
+    }
 }
 
 main .form form fieldset.splitbuttons .radio-wrapper-container {
@@ -1348,12 +1357,14 @@ main .form form fieldset.splitbuttons .radio-wrapper-container .radio-wrapper:la
 }
 
 main .form form fieldset.splitbuttons legend {
+    float: left;
     font-family: var(--font-family-lato);
     font-size: var(--form-font-size-xxs);
     font-weight:var(--font-weight-bold);
     color: var(--color-text-primary);
     line-height: 22.4px;
-    margin-right: 8px;
+    margin-top: 8px;
+    margin-bottom: 0;
     max-width: 102px;
     width: fit-content;
 }
@@ -1383,7 +1394,13 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper input {
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
-    padding: 11px 32px;
+    padding: 11px 22px;
+}
+
+@media (min-width: 410px) {
+    main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
+        padding: 11px 32px;
+    }
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) {
@@ -1394,17 +1411,32 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) la
     content: '';
     display: block;
     position: absolute;
-    left: 32px;
+    left: 22px;
     background: url("/icons/check-mark-new.svg") no-repeat left center;
     background-size: cover;
     width: 16px;
     height: 16px;
+}
 
+@media (min-width: 410px) {
+    main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label::before {
+        left: 32px;
+    }
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
-    color: var(--color-text-primary);
     cursor: pointer;
+    color: var(--color-text-primary);
+    font-size: var(--body-font-size-default);
+    font-weight: var(--font-weight-bold);
+    line-height: 160%;
+    letter-spacing: 0.28px;
+}
+
+@media (min-width: 1000px) {
+    main .form form .panel-wrapper.splitbuttons .radio-wrapper label {
+        letter-spacing: 0.32px;
+    }
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) {
@@ -1416,7 +1448,13 @@ main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) la
     align-items: center;
     color: var(--color-white);
     cursor: pointer;
-    padding-left: 56px;
+    padding-left: 46px;
+}
+
+@media (min-width: 410px) {
+    main .form form .panel-wrapper.splitbuttons .radio-wrapper:has(input:checked) label {
+       padding-left: 56px;
+    }
 }
 
 main .form form .panel-wrapper.splitbuttons .radio-wrapper.field-wrapper {

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -21,6 +21,27 @@ export default async function decorate(block) {
           }
         }
       });
+      const fieldsets = document.querySelectorAll('fieldset[class*="field-requesttype"]');
+      fieldsets.forEach((fieldset) => {
+        fieldset.classList.add('splitbuttons');
+      });
+
+      // Move radio-wrapper elements into a radio-wrapper-container div
+      form.querySelectorAll('fieldset.splitbuttons').forEach((fieldset) => {
+        const radioWrappers = fieldset.querySelectorAll('.radio-wrapper');
+        const radioWrapperContainer = fieldset.querySelector('.radio-wrapper-container');
+        if (radioWrappers.length > 0 && !radioWrapperContainer) {
+          const wrapperDiv = document.createElement('div');
+          wrapperDiv.classList.add('radio-wrapper-container');
+          const legend = fieldset.querySelector('legend');
+          radioWrappers.forEach((radioWrapper) => {
+            wrapperDiv.appendChild(radioWrapper);
+          });
+          fieldset.innerHTML = '';
+          fieldset.appendChild(legend);
+          fieldset.appendChild(wrapperDiv);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Ticket: https://herodigital.atlassian.net/browse/STERI016-61

Test URLs:
- Before: 
  - https://refresh-develop--shredit--stericycle.aem.page/refresh-testing/form
- After: 
  - https://steri016-61-split-button-am--shredit--stericycle.aem.page/refresh-testing/form

Note: To ensure the split button styling is applied correctly, the field in the JSON must have a name that starts with field-requesttype. This is because the style is exclusively applied to fieldsets with this naming convention, as demonstrated in the example below:

![image](https://github.com/user-attachments/assets/682fc9fa-1303-48c3-ba24-d3098418c242)
