### PR TITLE
STERI016-252: Remove redundant CSS rule for list-style-bullets

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -820,7 +820,6 @@ main .list-style-checkmarks ul {
   list-style: none;
 }
 
-main .list-style-bullets li::marker,
 main .list-style-checkmarks li::marker,
 main .list-style-orange-triangles li::marker,
 main .list-style-big-numbers li::marker,


### PR DESCRIPTION
Ticket: https://herodigital.atlassian.net/browse/STERI016-252

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/en-us/secure-shredding-services/one-off-shredding-service

After:
https://steri016-252-ch--shredit--stericycle.aem.live/en-us/secure-shredding-services/one-off-shredding-service