### PR TITLE
STERI016-355-regression-handle-am: Fix column block issue affecting c…

### DIFF
--- a/blocks/columns/default.css
+++ b/blocks/columns/default.css
@@ -430,7 +430,7 @@ main .section.columns-container .block.columns.columns-2-cols.icon-list > div > 
 }
 
 /* Center Content */
-main .section.centered-text.columns-container p.button-container {
+main .section.centered-text.columns-container .default-content-wrapper p.button-container {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -438,7 +438,7 @@ main .section.centered-text.columns-container p.button-container {
   margin: 0;
 }
 
-main .section.centered-text.columns-container p {
+main .section.centered-text.columns-container .default-content-wrapper p {
   text-align: center;
 }
 

--- a/blocks/columns/default.js
+++ b/blocks/columns/default.js
@@ -75,12 +75,21 @@ function applyVerticalCellAlignment(block) {
     if (!block.parentElement.parentElement.classList.contains('large-icon')) {
       d.style.alignItems = 'stretch';
     }
+
     if ((block.parentElement.parentElement.classList.contains('centered-text')
     || block.parentElement.parentElement.classList.contains('centered-headings'))
     && block.classList.contains('columns-8-cols')
     && block.classList.contains('columns-has-image')) {
       d.style.alignItems = 'center';
     }
+
+    if ((block.parentElement.parentElement.classList.contains('centered-text')
+    || block.parentElement.parentElement.classList.contains('centered-headings'))
+    && block.classList.contains('columns-8-cols')
+    && block.classList.contains('narrow-icons')) {
+      d.style.alignItems = 'center';
+    }
+
     if (d.querySelector('p > strong')) {
       d.querySelector('p').classList.add('button-container');
       if (d.querySelector('p > strong > a')) {


### PR DESCRIPTION
Ticket: https://herodigital.atlassian.net/browse/STERI016-355
Test URLs:
- Before: 
  - https://refresh-develop--shredit--stericycle.aem.live/refresh-testing/en-us
- After: 
  - https://steri016-355-regression-handle-am--shredit--stericycle.aem.live/refresh-testing/en-us

Another Link for Testing: https://steri016-355-regression-handle-am--shredit--stericycle.aem.live/en-us/secure-shredding-services/one-off-shredding-service

Note: For some reason, I noticed that the en-us page on the official site has changed—it no longer has the title for the flip-cards block. I'm not sure who made this change, but if you need me to fix it, just let me know.