### PR TITLE
STERI016-484: Update icon logic for flipcard

### DIFF
--- a/blocks/flip-cards/flip-cards.js
+++ b/blocks/flip-cards/flip-cards.js
@@ -110,12 +110,13 @@ export default async function decorate(block) {
           desc.appendChild(document.createTextNode(para.textContent));
         });
         desc.classList.add('clamp-description');
+        const existingSpan = page.querySelector('.icon') || '';
 
         const url = page.href;
         const readMoreButton = a(
           { class: page.classList.value || 'button primary', href: url, target: '_self' },
           page.title || 'Read More',
-          span({ class: 'icon icon-right-arrow', 'data-icon-src': '/icons/right-arrow.svg', style: '--mask-image: url(/icons/right-arrow.svg);' }),
+          existingSpan,
         );
         decorateButtons(readMoreButton);
         const pButton = document.createElement('p');


### PR DESCRIPTION
This pull request includes a small change to the `blocks/flip-cards/flip-cards.js` file. The change modifies the `decorate` function to reuse an existing span element with the class `icon` if it exists, instead of creating a new one. This helps in avoiding duplicate icons on the page.

* [`blocks/flip-cards/flip-cards.js`](diffhunk://#diff-9cf3d43188a0123f60cd5826f98e069a9b51212003581ed978f4c5a1b9581336R113-R119): Modified the `decorate` function to reuse an existing span element with the class `icon` if it exists, instead of creating a new one.Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Ticket: https://herodigital.atlassian.net/browse/STERI016-484

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/refresh-testing/about
After:
https://steri016-484-ch--shredit--stericycle.aem.live/refresh-testing/about
