### PR TITLE
STERI016-445: Hide notification banner carousel elements

### DIFF
--- a/blocks/banner/banner.css
+++ b/blocks/banner/banner.css
@@ -62,7 +62,7 @@
   }
 
   .block.banner > span {
-    display: block;
+    display: none; /* Hide the span element */
     width: 50px;
     gap: 50px;
     color: var(--color-white);
@@ -141,6 +141,8 @@
 
 button.fa-chevron-left,
 button.fa-chevron-right {
+  opacity: 0; /* Hide the button */
+  visibility: hidden;
   box-sizing: border-box;
   position: relative;
   display: block;


### PR DESCRIPTION
This pull request includes changes to the `blocks/banner/banner.css` file to hide certain elements in the banner block.

Styling updates:

* [`blocks/banner/banner.css`](diffhunk://#diff-843764785a85c27f8694d47e58890c2d497eb727a4fedeac131531e840ff3b8bL65-R65): Changed the `display` property of the `span` element inside the `.block.banner` class to `none` to hide it.
* [`blocks/banner/banner.css`](diffhunk://#diff-843764785a85c27f8694d47e58890c2d497eb727a4fedeac131531e840ff3b8bR144-R145): Added `opacity: 0` and `visibility: hidden` to the `button.fa-chevron-left` and `button.fa-chevron-right` selectors to hide the buttons.Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Ticket: https://herodigital.atlassian.net/browse/STERI016-445

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/refresh-testing/hero
After:
https://steri016-445-ch--shredit--stericycle.aem.live/refresh-testing/hero