### PR TITLE
STERI016-489: Update text truncation for flip cards

### DIFF
--- a/blocks/flip-cards/flip-cards.css
+++ b/blocks/flip-cards/flip-cards.css
@@ -73,11 +73,8 @@
 }
 
 .flip-cards > .wrapper > div .clamp-title {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  max-height: calc(1.5em* 2);
   overflow: hidden;
-  text-overflow: ellipsis;
   margin-bottom: 0;
 }
 

--- a/blocks/simple-cta/simple-cta.css
+++ b/blocks/simple-cta/simple-cta.css
@@ -209,6 +209,7 @@ main .section > div.simple-cta-wrapper {
 
 .simple-cta.slim .simple-cta-content .button-container a {
   margin: 16px auto;
+  margin-bottom: 0;
 }
 
 .simple-cta.slim .simple-cta-content-text {

--- a/templates/service-location-page/service-location-page.css
+++ b/templates/service-location-page/service-location-page.css
@@ -59,6 +59,10 @@ main .section > div.hero-wrapper {
   margin-bottom: 30px;
 }
 
+.service-location-page .simple-cta.slim .simple-cta-asset {
+  width: fit-content;
+}
+
 .with-sidebar .section.flip-cards-container .flip-cards-wrapper {
   padding: 0 24px;
 }


### PR DESCRIPTION
This pull request includes several CSS changes to improve the styling of flip cards, simple CTA buttons, and service location pages. The most important changes are grouped by their themes below:

Improvements to flip cards:

* [`blocks/flip-cards/flip-cards.css`](diffhunk://#diff-123bd5275058f03f0994a82a6a0919a14846137a93769df7275c292b3defd505L76-L80): Adjusted the title clamping method to use `max-height` instead of `-webkit-line-clamp` for better cross-browser compatibility.

Adjustments to simple CTA buttons:

* [`blocks/simple-cta/simple-cta.css`](diffhunk://#diff-543fe5c6d89f92679b26e2a69fed17bd940fef82798b2cb4e6dcc95b5ab45da2R212): Added `margin-bottom: 0` to the button container to ensure consistent spacing.

Enhancements to service location pages:

* [`templates/service-location-page/service-location-page.css`](diffhunk://#diff-6ba20d4e93a6d585e38ae5a298d31b4262fdd4020885dd35ea6b43e7c03177a8R62-R65): Added a new rule to set the width of `.simple-cta-asset` to `fit-content` for better layout control.

Ticket: https://herodigital.atlassian.net/browse/STERI016-489

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/en-us/service-locations/omaha
After:
https://steri016-489-ch--shredit--stericycle.aem.live/en-us/service-locations/omaha