### PR TITLE
no-ref: Fix cards spacing issue

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -75,7 +75,7 @@
 
 .cards > ul > li > .card-head .icon {
   width: 100%;
-  height: 164px;
+  height: auto;
 }
 
 .cards.cards.full-width > ul > li > .card-head .icon {
@@ -193,6 +193,7 @@
 
 .cards.cards.full-width > ul > li > .card-body > .card-section > p.button-container a {
   margin: 0;
+  margin-top: 16px;
 }
 
 .cards > ul > li > .card-body > .card-section > p.button-container:last-child a.button {
@@ -381,11 +382,6 @@
   }
 
   .cards.full-width > ul > li > .card-body > .card-section:not(.button-container) {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 24px;
-    max-width: 100%;
     margin: 0;
   }
 

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -402,6 +402,12 @@
     object-fit: cover;
   }
 
+  .cards.full-width > ul > li > .card-body > .card-section.button-container a.button.primary {
+    margin: 0;
+  }
+}
+
+@media (min-width: 1400px) /* breakpoint-xl */ {
   .cards.full-width > ul > li > .card-body > .card-section > p.button-container:last-child {
     flex: 1;
     margin: 0;
@@ -410,9 +416,5 @@
     right: 0;
     top: 50%;
     transform: translateY(-50%);
-  }
-
-  .cards.full-width > ul > li > .card-body > .card-section.button-container a.button.primary {
-    margin: 0;
   }
 }

--- a/templates/service-location-page-2/service-location-page-2.css
+++ b/templates/service-location-page-2/service-location-page-2.css
@@ -8,6 +8,15 @@
   margin-bottom: 30px;
 }
 
+.service-location-page-2 .cards > ul > li > .card-head .icon {
+  width: 100%;
+  height: 164px;
+}
+
+.service-location-page-2 .cards.full-width.light > ul > li > .card-body > .card-section:not(.button-container) > p {
+  margin: 0;
+}
+
 .service-location-page-2 .location {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This pull request includes several CSS changes to improve the layout and styling of card components across different pages. The most important changes include adjustments to the height and margin properties, as well as the removal of some flexbox properties.

https://herodigital.atlassian.net/browse/STERI016-493

### Adjustments to card component styling:

* [`blocks/cards/cards.css`](diffhunk://#diff-f528cc2e2c8fa6d0933ed69cb88555d4381a8ffff676ea46ad8525a8ce94b334L78-R78): Changed the height of the `.icon` class within `.card-head` to be `auto` instead of a fixed `164px`.
* [`blocks/cards/cards.css`](diffhunk://#diff-f528cc2e2c8fa6d0933ed69cb88555d4381a8ffff676ea46ad8525a8ce94b334R196): Added a `margin-top` of `16px` to the `.button-container a` class within `.card-section`.
* [`blocks/cards/cards.css`](diffhunk://#diff-f528cc2e2c8fa6d0933ed69cb88555d4381a8ffff676ea46ad8525a8ce94b334L384-L388): Removed the flexbox properties (`display: flex;`, `flex-direction: row;`, `align-items: center;`, `gap: 24px;`, `max-width: 100%;`) from the `.card-section:not(.button-container)` class within `.card-body`.

### Additions to service location page styling:

* [`templates/service-location-page-2/service-location-page-2.css`](diffhunk://#diff-9be2a87d34b22c9862bc8b8b45037029bb198b02246a389957d5a07107d9ca87R11-R19): Added styling for the `.icon` class within `.card-head` to set the width to `100%` and height to `164px`.
* [`templates/service-location-page-2/service-location-page-2.css`](diffhunk://#diff-9be2a87d34b22c9862bc8b8b45037029bb198b02246a389957d5a07107d9ca87R11-R19): Set the margin to `0` for the `p` elements within `.card-section:not(.button-container)` in `.cards.full-width.light`.


Ticket: https://herodigital.atlassian.net/browse/STERI016-493

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/refresh-testing/cards
https://refresh-develop--shredit--stericycle.aem.live/en-us/service-locations/omaha
https://refresh-develop--shredit--stericycle.aem.live/en-us/service-locations/new-york

After:
https://steri0116-no-ref-ch--shredit--stericycle.aem.live/refresh-testing/cards
https://steri0116-no-ref-ch--shredit--stericycle.aem.live/en-us/service-locations/omaha
https://steri0116-no-ref-ch--shredit--stericycle.aem.live/en-us/service-locations/new-york
