### PR TITLE
STERI016-488: Fix header close event action

### DIFF
--- a/blocks/header/utils.js
+++ b/blocks/header/utils.js
@@ -129,6 +129,7 @@ function setupModal(triggerElement, modalElement) {
 
       // remove open class to hamburger menu
       const hamburger = document.querySelector('.hamburger-menu');
+
       if (hamburger) {
         hamburger.classList.remove('open');
       }
@@ -137,6 +138,7 @@ function setupModal(triggerElement, modalElement) {
     modalElement.classList.add(MOBILE_MENU_OPEN_CLASSNAME);
     nav.classList.remove(MOBILE_MENU_OPEN_CLASSNAME);
 
+    closeNavigationMenu();
     trapFocus(modalElement, closeModalFn);
   }
 


### PR DESCRIPTION
This pull request includes changes to the `blocks/header/utils.js` file to improve the functionality of the modal setup. The most important changes include adding a check for the hamburger menu element and ensuring the navigation menu is closed when the modal is opened.

Improvements to modal setup:

* [`blocks/header/utils.js`](diffhunk://#diff-6ec11a8e152cf031b68a2d785f356a5500812290a59dc79fc2ddd95c684ef8d6R132): Added a check to ensure the hamburger menu element exists before attempting to remove the 'open' class.
* [`blocks/header/utils.js`](diffhunk://#diff-6ec11a8e152cf031b68a2d785f356a5500812290a59dc79fc2ddd95c684ef8d6R141): Added a call to `closeNavigationMenu()` to ensure the navigation menu is closed when the modal is opened.

Ticket: https://herodigital.atlassian.net/browse/STERI016-488

Test URLs:

Before:
https://refresh-develop--shredit--stericycle.aem.live/en-us

After:
https://steri016-488-ch--shredit--stericycle.aem.live/en-us

