### PR TITLE
feat: Use CSP for scripts with (cached) nonce + strict-dynamic

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,15 +2,20 @@
 <html>
 
 <head>
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
+    move-as-header="true"
+  >
   <title>Page not found</title>
-  <script type="text/javascript">
+  <script nonce="aem" type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-  <script type="module">
+  <script nonce="aem" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script nonce="aem" type="module">
     import { sampleRUM } from '/scripts/aem.js';
 
     window.addEventListener('load', () => {

--- a/head.html
+++ b/head.html
@@ -1,6 +1,11 @@
+<meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic'; base-uri 'self'; object-src 'none';"
+  move-as-header="true"
+>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta charset="UTF-8">
-<script src="/scripts/aem.js" type="module"></script>
-<script src="/scripts/scripts.js" type="module"></script>
+<script nonce="aem" src="/scripts/aem.js" type="module"></script>
+<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="preconnect" href="https://assets.adobedtm.com"/>


### PR DESCRIPTION
Enable Content Security Policy for scripts using `strict-dynamic` and (cached) nonce.

Note: The CSP doesn't have to be configured using a meta tag. We can also add `script-src 'nonce-aem' 'strict-dynamic';` directly into the headers configuration. I'm doing it like this, so people can test it out directly on this PR, without affecting the main branch. The `nonce="aem"` on the trusted scripts is required in the code.

The following is our current understanding on what would be the level of protection. 
Of course, things can change with research and finding ways to bypass, that's why CSP is always about having it as a last line of defence, rather than your main defence. 🙂

**1. Protected even if the nonce is cached**

✅  `.innerHTML` for XSS
✅  `.outerHTML` for XSS
✅  `.insertAdjecentHTML` for XSS
✅  `.setHTMLUnsafe` for XSS
✅  `eval` / `setTimeout` / `setInterval` / Function for XSS
✅  `javascript:` protocol in the href/src attributes
✅  `location.href` / `location.assign()` / `location.replace` for XSS
✅  attribute event handlers (`onclick`, `onblur`, `onload`, `onerror` etc.) for XSS
✅  stored/reflected XSS
* as long as there is no server side manipulation of the HTML in the customer's CDN

**2. not protected, because the nonce is cached**

❌  `document.write` / `document.writeln` -> because you could get the nonce and use it in the exploit

**3.not protected for other reasons**

❌  `document.createRange().createContextualFragment` -> whether the nonce is cached/known is irrelevant, scripts are always executed with `strict-dynamic`.
❌  `src` attribute of a `<script>` tag created by `document.createElement('script')` /  text content of a `<script>` tag created by `document.createElement('script')` / `import` -> permitted by `strict-dynamic`

**4. not protected by CSPs in general**
Script-less attacks
❌  HTML injection,  DOM clobbering, etc.

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.live/
- After: 
  - https://csp--shredit--stericycle.aem.live/
