### PR TITLE
DA Live Preview Script

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -879,4 +879,10 @@ async function loadPage() {
   loadDelayed();
 }
 
+async function loadDa() {
+  if (!new URL(window.location.href).searchParams.get('dapreview')) return;
+  // eslint-disable-next-line import/no-unresolved
+  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
+}
+
 loadPage();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -879,10 +879,10 @@ async function loadPage() {
   loadDelayed();
 }
 
-async function loadDa() {
+(async function loadDa() {
   if (!new URL(window.location.href).searchParams.get('dapreview')) return;
   // eslint-disable-next-line import/no-unresolved
   import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
-}
+}());
 
 loadPage();


### PR DESCRIPTION
Add the loadDa() function to scripts.js to enable live preview in DA per https://github.com/adobe/da-live/wiki/Upgrade-Developer-Guide#enable

Test URLs:
- Before: 
  - https://da--shred-it--stericycle.aem.page/
- After: 
  - https://da-live-script--shred-it--stericycle.aem.page/
