### PR TITLE
DA Live Preview

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,7 +14,7 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script nonce="aem" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
   <script nonce="aem" type="module">
     import { sampleRUM } from '/scripts/aem.js';
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -879,4 +879,10 @@ async function loadPage() {
   loadDelayed();
 }
 
+(async function loadDa() {
+  if (!new URL(window.location.href).searchParams.get('dapreview')) return;
+  // eslint-disable-next-line import/no-unresolved
+  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
+}());
+
 loadPage();


### PR DESCRIPTION
Add loadDa() function to script.js and update 404.html to enable DA Live Preview, as per https://github.com/adobe/da-live/wiki/Upgrade-Developer-Guide#live-preview

Test URLs:
- Before: 
  - https://main--shred-it--stericycle.aem.page/
- After: 
  - https://da-live-preview--shred-it--stericycle.aem.page/
