### PR TITLE
Handle "5-Feb-25" date string format now present in in-the-news-index.json

### DIFF
--- a/blocks/paginated-list/paginated-list.js
+++ b/blocks/paginated-list/paginated-list.js
@@ -1,5 +1,5 @@
 import { readBlockConfig } from '../../scripts/aem.js';
-import { fetchQueryIndex, getDateFromExcel } from '../../scripts/scripts.js';
+import { fetchQueryIndex, getDateFromString } from '../../scripts/scripts.js';
 
 let sessionKey = 'press-releases';
 
@@ -51,7 +51,7 @@ async function buildPagination(ul, controls, sheet, page) {
       listItem.append(desc);
     }
     const prSpan = document.createElement('span');
-    prSpan.textContent = formatDate(getDateFromExcel(release.date));
+    prSpan.textContent = formatDate(getDateFromString(release.date));
     prSpan.classList.add('date-published');
     listItem.append(prSpan);
     ul.appendChild(listItem);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -82,6 +82,17 @@ export function getDateFromExcel(date) {
   return date;
 }
 
+/**
+ * Converts string date format like "D-Month-YY" to a Date object
+ * @returns {Date} Date object
+ */
+export function getDateFromString(date) {
+  if (!Number.isNaN(date)) {
+    return new Date(date);
+  }
+  return date;
+}
+
 export const formatDate = (date) => date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',


### PR DESCRIPTION
Wasn't sure how far to go with this. Previously the index return this as a number I assume in seconds and the function getDateFromExcel converted to milliseconds and returned a data object. Added a new function that simply converts the string to Date object, leaving the other instances of getDateFromExcel in place.

Fix STER-56

Test URLs:
- Before: 
  - https://da--shred-it--stericycle.aem.live/
- After: 
  - https://ster-56--shred-it--stericycle.aem.live/
