### PR TITLE
Add rounded borders and spacing for card images and titles

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -88,7 +88,6 @@
   object-fit: contain;
 }
 
-/* Add rounded borders to images in card sections */
 .cards > ul > li > .card-body > .card-section picture img {
   border-radius: 12px;
 }
@@ -97,9 +96,8 @@
   border-radius: 16px;
 }
 
-/* Add spacing above titles in card sections */
 .cards > ul > li > .card-body > .card-section h3 {
-  margin-top: 18px;
+  margin: 24px auto 0;
 }
 
 .cards > ul > li > .card-body {
@@ -220,7 +218,7 @@
 
 
 .cards > ul > li > .card-body > hr {
-  margin: 1rem auto;
+  margin: 24px auto;
   border: 0.5px solid #b2b1b1;
   opacity: .25;
   color: inherit;


### PR DESCRIPTION
[Fix #STERICMS-870](https://herodigital.atlassian.net/browse/STERICMS-870)

- Implemented rounded borders for images in card sections, with different radii for primary cards.
- Added margin above titles in card sections to improve layout and spacing.

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.page/drafts/commercial-page-revamp/hard-drive-destruction-redesign
- After: 
  - https://STERICMS-870-rounded-cards--shredit--stericycle.aem.page/drafts/commercial-page-revamp/hard-drive-destruction-redesign

<img width="1335" height="799" alt="image" src="https://github.com/user-attachments/assets/fd80d227-8ba0-4e90-91f7-26b1a652d2d6" />
