### PR TITLE
Enhance video block styling and responsiveness

### DIFF
--- a/blocks/columns/default.css
+++ b/blocks/columns/default.css
@@ -402,6 +402,7 @@ main .section.blue-headings .columns span.icon > img {
 
 main .block.columns.video iframe {
   aspect-ratio: 16 / 9;
+  box-shadow: 0 0 4px 0 rgb(0 0 0 / 25%);
 }
 
 main .section.columns-container .block.columns.columns-2-cols.icon-list > div > div > p.button-container:has(a) > a.button {
@@ -906,13 +907,13 @@ main .section.columns-container.close-vertical {
   main .block.columns.video.columns-2-cols > div div:last-of-type:has(iframe) {
     display: flex;
     flex-direction: column;
-    margin-left: 8.3333%;
   }
 
   main .block.columns.video.columns-2-cols > div div:first-of-type:has(iframe) {
     display: flex;
     flex-direction: column;
-    margin-right: 8.3333%;
+    align-items: flex-end;
+    margin-right: 1%;
   }
 
   main .block.columns.video.block.columns-2-cols > div div:has(iframe) {
@@ -1074,5 +1075,20 @@ main .section.columns-container.close-vertical {
   /* 4 or more cards */
   .columns.steps-secondary > div:has(> div:nth-child(4)) > div > p:last-of-type {
     max-width: 100%;
+  }
+}
+
+@media (max-width: 991px) {
+  .columns.video.block .video-iframe {
+    width: 100vw;
+    max-width: 90vw;
+    aspect-ratio: 16 / 9;
+  }
+  .columns.video.block .video-iframe iframe {
+    width: 100vw;
+    max-width: 80vw;
+    min-width: 0;
+    min-height: 180px;
+    aspect-ratio: 16 / 9;
   }
 }

--- a/blocks/columns/default.css
+++ b/blocks/columns/default.css
@@ -1084,6 +1084,7 @@ main .section.columns-container.close-vertical {
     max-width: 90vw;
     aspect-ratio: 16 / 9;
   }
+
   .columns.video.block .video-iframe iframe {
     width: 100vw;
     max-width: 80vw;

--- a/blocks/hero-banner/hero-banner.js
+++ b/blocks/hero-banner/hero-banner.js
@@ -1,5 +1,4 @@
 export default function decorate(block) {
-  console.log('block', block);
   const isImageVariant = block.classList?.contains('hero-banner-image');
   const isFullWidthVariant = block.classList?.contains('hero-banner-full');
   let wrapper = block.children[0];

--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -103,7 +103,7 @@
         margin: 0 auto;
 
     }
-    
+
     .section.video-container.video-row .video-wrapper {
         flex: 1 0 0%;
     }


### PR DESCRIPTION
Fix #[STERICMS-873](https://herodigital.atlassian.net/browse/STERICMS-873)

- Added box-shadow to video iframes for improved visual depth.
- Adjusted margin and alignment for better layout on video columns.
- Introduced media queries to ensure video iframes are responsive on smaller screens.

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.page/drafts/commercial-page-revamp/customer-portal-redesign
- After: 
  - https://STERICMS-873-video-updates--shredit--stericycle.aem.page/drafts/commercial-page-revamp/customer-portal-redesign
 
<img width="1555" height="563" alt="image" src="https://github.com/user-attachments/assets/89f269c4-a203-4c46-ab90-9d0d5d345656" />

