### PR TITLE
STERICMS-894 Update tab container styles

### DIFF
--- a/blocks/tabs/default.css
+++ b/blocks/tabs/default.css
@@ -40,6 +40,7 @@ main .section.tabs-container:has(.cta-list) > .default-content-wrapper > p > a {
     overflow-x: auto;
     border-bottom: 1px solid var(--color-grey200);
     scrollbar-width: none;
+    height: 100%;
 }
 
 .block.tabs .tabs-list::after {


### PR DESCRIPTION
Fix #[STERICMS-894](https://herodigital.atlassian.net/browse/STERICMS-894)

Test URLs:
- Before: 
  - https://stage-us.shredit.com/en-us/who-we-serve/healthcare
- After: 
  - https://stericms-894-tabs-height--shredit--stericycle.aem.page/en-us/who-we-serve/healthcare

<img width="1614" height="957" alt="image" src="https://github.com/user-attachments/assets/c69e3ccf-c006-4a77-9824-db277244f56f" />

