### PR TITLE
changes to support forms loading from sharepoint when on DA EDS urls

### DIFF
--- a/blocks/form/lib/docform.js
+++ b/blocks/form/lib/docform.js
@@ -17,7 +17,7 @@ export async function extractFormDefinition(block) {
     const path = container.href;
     if (path.endsWith('.json')) {
       const { pathname } = new URL(path);
-      const definition = await fetchForm(path);
+      const definition = await fetchForm(window.location.origin.includes('shredit.com') ? path : `https://main--shredit--stericycle.aem.live${pathname}`);
       if (definition && definition[':type'] === 'sheet') {
         const transformer = new DocBasedFormToAF();
         const formDef = transformer.transform(definition, pathname);

--- a/blocks/form/lib/util.js
+++ b/blocks/form/lib/util.js
@@ -242,7 +242,7 @@ export function appendFragment(wrapper, value) {
     const fragmentUrl = new URL(value);
     const fragmentPath = fragmentUrl.pathname;
     const url = fragmentPath.endsWith('.html') ? fragmentPath.replace('.html', '.plain.html') : `${fragmentPath}.plain.html`;
-    fetch(url).then(async (resp) => {
+    fetch(url.startsWith('/forms') ? `https://main--shredit--stericycle.aem.live${url}` : `${window.location.origin}${url}`).then(async (resp) => {
       if (resp.ok) {
         wrapper.innerHTML = await resp.text();
         wrapper.querySelectorAll('a[href]').forEach((link) => {

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -18,8 +18,9 @@ import {
  * @returns {HTMLElement} The root element of the fragment
  */
 export async function loadFragment(path) {
-  if (path && path.startsWith('/')) {
-    const resp = await fetch(`${path}.plain.html`);
+  if (path) {
+    const pathname = path.startsWith('/') ? path : new URL(path).pathname;
+    const resp = await fetch(pathname.startsWith('/forms') ? `https://main--shredit--stericycle.aem.live${pathname}.plain.html` : `${path}.plain.html`);
     if (resp.ok) {
       const main = document.createElement('main');
       main.innerHTML = await resp.text();

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -307,6 +307,9 @@ function getMetadata(name, doc = document) {
   const meta = [...doc.head.querySelectorAll(`meta[${attr}="${name}"]`)]
     .map((m) => m.content)
     .join(', ');
+  if (meta && meta.startsWith('/forms')) {
+    return `https://main--shredit--stericycle.aem.live${meta}`;
+  }
   return meta || '';
 }
 
@@ -555,7 +558,8 @@ async function fetchPlaceholders(prefix = 'default') {
   window.placeholders = window.placeholders || {};
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
+      const updatedPrefix = prefix.includes('forms') ? `https://main--shredit--stericycle.aem.live${prefix}` : prefix;
+      fetch(`${prefix === 'default' ? '' : updatedPrefix}/placeholders.json`)
         .then((resp) => {
           if (resp.ok) {
             return resp.json();


### PR DESCRIPTION
Fix #STER-71

Test URLs:
- Before: 
  - https://main--shred-it--stericycle.aem.live/
- After: 
  - https://ster-71--shred-it--stericycle.aem.live/
