### PR TITLE
only display Buy Now buttons for locations if en-us page

### DIFF
--- a/blocks/service-location-map/service-location-map.js
+++ b/blocks/service-location-map/service-location-map.js
@@ -97,7 +97,7 @@ const locDivCreation = (location, ph) => {
     );
   }
 
-  if (location['buy-now']) {
+  if (location['buy-now'] && getLocale() === 'en-us') {
     locationDiv.appendChild(
       a(
         { class: 'buy-now', href: location['buy-now'] },

--- a/templates/service-location-page-2/service-location-page-2.js
+++ b/templates/service-location-page-2/service-location-page-2.js
@@ -103,10 +103,12 @@ const createLocDiv = async () => {
     const zipCodeText = zipCode ? `zip=${zipCode}&` : '';
     // eslint-disable-next-line max-len
     const url = `https://shop-shredit.stericycle.com/commerce_storefront_ui/walkin.aspx?${zipCodeText}adobe_mc=MCMID%3D47228127826121584233605487843606294434%7CMCORGID%3DFB4A583F5FEDA3EA0A495EE3%2540AdobeOrg%7CTS%3D1729746363`;
-    const buyNowAnchor = a({ class: 'button primary', href: url, target: '_blank' }, ph.buynowtext || 'Buy Now');
-    decorateButtons(buyNowAnchor);
-    dropOffDiv.append(buyNowAnchor);
-    locationDiv.append(dropOffDiv);
+    if (getLocale() === 'en-us') {
+      const buyNowAnchor = a({ class: 'button primary', href: url, target: '_blank' }, ph.buynowtext || 'Buy Now');
+      decorateButtons(buyNowAnchor);
+      dropOffDiv.append(buyNowAnchor);
+      locationDiv.append(dropOffDiv);
+    }
   }
 
   const addressParts = [

--- a/templates/service-location-page/service-location-page.js
+++ b/templates/service-location-page/service-location-page.js
@@ -87,12 +87,13 @@ const createLocDiv = async () => {
     const zipCodeText = zipCode ? `zip=${zipCode}&` : '';
     // eslint-disable-next-line max-len
     const url = `https://shop-shredit.stericycle.com/commerce_storefront_ui/walkin.aspx?${zipCodeText}adobe_mc=MCMID%3D47228127826121584233605487843606294434%7CMCORGID%3DFB4A583F5FEDA3EA0A495EE3%2540AdobeOrg%7CTS%3D1729746363`;
-    const buyNowAnchor = a({ class: 'button primary', href: url, target: '_blank' }, ph.buynowtext || 'Buy Now');
-    decorateButtons(buyNowAnchor);
-    dropOffDiv.append(buyNowAnchor);
-    locationDiv.append(dropOffDiv);
+    if (getLocale() === 'en-us') {
+      const buyNowAnchor = a({ class: 'button primary', href: url, target: '_blank' }, ph.buynowtext || 'Buy Now');
+      decorateButtons(buyNowAnchor);
+      dropOffDiv.append(buyNowAnchor);
+      locationDiv.append(dropOffDiv);
+    }
   }
-
   if (nearByLocations.length > 0) {
     const nearByDiv = div({ class: 'nearby-locations' });
     nearByDiv.append(h4(`${ph.nearbylocationstext || 'See our nearby locations'}:`));


### PR DESCRIPTION
Buy now e-commerce links should only appear on drop-off service page and location pages that are en-us, per client.

Fix https://herodigital.atlassian.net/browse/STER-94

Test URLs:
- Before: 
  - https://canada-da--shred-it--stericycle.aem.live/en-ca/secure-shredding-services/drop-off-shredding
- After: 
  - https://remove-buy-now--shred-it--stericycle.aem.live/en-ca/secure-shredding-services/drop-off-shredding
