### PR TITLE
STERICMS-899 making sure that JS date is timezone agnostic to avoid m…

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -93,7 +93,7 @@ export function getDateFromString(date) {
   return date;
 }
 
-export const formatDate = (date) => date.toLocaleDateString('en-US', {
+export const formatDate = (date) => new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()).toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: '2-digit',


### PR DESCRIPTION
…ismatch

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #STERICMS-889

https://herodigital.atlassian.net/browse/STERICMS-889

Test URLs:
- Before: 
  - https://main--shred-it--stericycle.aem.page/
- After: 
  - https://<branch>--shred-it--stericycle.aem.page/
