### PR TITLE
Remove unnecessary margin from hero banner styles for cleaner layout

### DIFF
--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -44,7 +44,6 @@ main .section > div.hero-banner-wrapper {
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-    margin: 0 2rem
 }
 
 .hero-banner-content-text .hero-banner-heading {


### PR DESCRIPTION
Fix #[STERICMS-922](https://herodigital.atlassian.net/browse/STERICMS-922)

Test URLs:
- Before: 
  - https://main--shredit--stericycle.aem.page/en-us/secure-shredding-services/one-off-shredding-service
- After: 
  - https://stericms-922-hero-banner--shredit--stericycle.aem.page/en-us/secure-shredding-services/one-off-shredding-service