### PR TITLE
STERICMS-983 bugfix font render

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -338,6 +338,11 @@ p, dl, ol, ul, pre, blockquote {
   margin: 0;
 }
 
+html body,
+html ul {
+  font-family: var(--font-family-body);
+}
+
 main:has(.section.two-column.shredded-paper-background-column) .section.column-with-list .columns-wrapper,
 main:has(.section.two-column.hard-drive-background) .section.column-with-list .columns-wrapper,
 main:has(.section.shredded-paper-background) .section.column-with-list .columns-wrapper {


### PR DESCRIPTION
### Summary

STERICMS-983 — Service location pages (San Bernardino, New York) rendering with Roboto instead of Lato
https://herodigital.atlassian.net/browse/STERICMS-983

### Root cause

The BirdEye widget injects a Google Fonts (Roboto) <link> on select service-location pages. Roboto's stylesheet adds a font-family rule with specificity 0-0-1 that wins the CSS cascade over the existing Lato rule on body, html, and ul elements — only on the pages where BirdEye is active.

### Fix

Added a compound-selector override in styles/styles.css immediately after the existing block-element reset:

```css
html body,
html ul {
    font-family: var(--font-family-body);
    }
```

Specificity 0-0-2 beats BirdEye's 0-0-1, regardless of stylesheet load order. Also removed an unused loadScript import from scripts/scripts.js (pre-existing lint error surfaced during this fix).

### Test URLs

#### Before:

- <https://main--shred-it--stericycle.aem.page/en-us/service-locations/san-bernardino>
- <https://main--shred-it--stericycle.aem.page/en-us/service-locations/new-york>

#### After:

- <https://bugfix-stericms-983-font-r-main--shred-it--stericycle.aem.page/en-us/service-locations/san-bernardino>
- <https://bugfix-stericms-983-font-r-main--shred-it--stericycle.aem.page/en-us/service-locations/new-york>

#### Reference (unaffected page — expected behavior):

- <https://main--shred-it--stericycle.aem.page/en-us/service-locations/cedar-rapids>