### PR TITLE
[MAIN] STERICMS-959 — OneTrust cookie banner reappears after Accept/Reject on non-production hosts

### DIFF
--- a/scripts/otconfing.js
+++ b/scripts/otconfing.js
@@ -1,22 +1,18 @@
 import { loadScript } from './aem.js';
 
-export default function getOneTrustConfig(pageUrl) {
-  const otConfigMap = [
-    {
-      pattern: /^https?:\/\/(www\.)?shredit\.com(\/|$)/,
-      domainScript: '94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c',
-      script: 'https://cdn.cookielaw.org/consent/94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c/OtAutoBlock.js',
-    },
-    {
-      pattern: /^https?:\/\/dev-us\.shredit\.com(\/|$)/,
-      domainScript: '94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c-test',
-      script: 'https://cdn.cookielaw.org/consent/94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c-test/OtAutoBlock.js',
-    },
-  ];
+const PROD_CONFIG = {
+  domainScript: '94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c',
+  script: 'https://cdn.cookielaw.org/consent/94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c/OtAutoBlock.js',
+};
 
-  const matched = otConfigMap.find((config) => config.pattern.test(pageUrl));
-  if (matched) return matched;
-  return otConfigMap[0]; // default config
+const TEST_CONFIG = {
+  domainScript: '94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c-test',
+  script: 'https://cdn.cookielaw.org/consent/94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c-test/OtAutoBlock.js',
+};
+
+export default function getOneTrustConfig(pageUrl) {
+  if (/^https?:\/\/(www\.)?shredit\.com(\/|$)/.test(pageUrl)) return PROD_CONFIG;
+  return TEST_CONFIG;
 }
 
 async function addCookieBanner() {


### PR DESCRIPTION
### Summary

STERICMS-959 — OneTrust cookie banner reappears after Accept/Reject on non-production hosts
https://herodigital.atlassian.net/browse/STERICMS-959

### Root cause

`scripts/otconfing.js` defaulted any unmatched host to the production OneTrust domain script (`94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c`), which OneTrust authorizes only for `shredit.com`. Preview (`*.aem.page`), live mirror (`*.aem.live`), and `localhost` fell through to that production ID, so consent could not be recorded and the banner reappeared after every Accept/Reject. Only reproduces from consent-required regions (e.g. Bogotá/EU), not US regions.

### Fix

Rewrote `getOneTrustConfig()` in `scripts/otconfing.js` to return the production config only for the production domains and the `-test` config as the fail-safe default for every other host:

```js
export default function getOneTrustConfig(pageUrl) {
  if (/^https?:\/\/(www\.)?shredit\.com(\/|$)/.test(pageUrl)) return PROD_CONFIG;
  return TEST_CONFIG;
}
```

`TEST_CONFIG` uses domain script `94a9f9f7-2ccd-4f46-b1a1-d11d479ed08c-test`. No change to `shredit.com` / `www.shredit.com`, no new dependencies, no build step, `aem.js` untouched.

### Test URLs

> OneTrust only renders the banner from a consent-required region (e.g. Bogotá/EU) — not from US regions.

#### Before:

- <https://main--shred-it--stericycle.aem.page/en-us>

#### After:

- <https://bugfix-stericms-959-onetrust--shred-it--stericycle.aem.page/en-us>
