### PR TITLE
fix: recognize dev-us.shredit.com as dev environment to load Adobe La…

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -112,7 +112,9 @@ function arraysHaveMatchingItem(array1, array2) {
 
 export function getEnvironment() {
   const { hostname } = window.location;
-  if (hostname === 'localhost' || hostname.endsWith('.aem.page') || hostname.endsWith('.aem.live') || (hostname.startsWith('stage') && hostname.endsWith('.shredit.com'))) {
+  const isShredit = hostname.endsWith('.shredit.com');
+  if (hostname === 'localhost' || hostname.endsWith('.aem.page') || hostname.endsWith('.aem.live')
+    || (isShredit && (hostname.startsWith('stage') || hostname.startsWith('dev')))) {
     return 'dev';
   }
   if (hostname === 'www.shredit.com') {


### PR DESCRIPTION
…unch

getEnvironment() was returning 'unknown' for dev-us.shredit.com because only stage*.shredit.com subdomains were matched. This caused initLaunch() to bail out early, skipping the Adobe Launch script entirely and leaving Dev without GTM and all downstream tags (GA4, Floodlight, LinkedIn, Microsoft Ads, Google Ads Remarketing).

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: 
  - https://main--shred-it--stericycle.aem.page/
- After: 
  - https://STERICMS-fix-dev-env-adobe-launch--shred-it--stericycle.aem.page/
